### PR TITLE
Improve tests

### DIFF
--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -14,5 +14,23 @@ def test_parse_ehi_plain():
     assert result == ["payload1", "payload2"]
 
 
+def test_parse_ehi_base64():
+    raw = "line1\nline2"
+    b64 = base64.b64encode(raw.encode())
+    result = parse_ehi(b64)
+    assert result == ["line1", "line2"]
+
+
+def test_parse_ehi_zip(tmp_path):
+    import zipfile, json
+    payload = {"payload": "zipline"}
+    zpath = tmp_path / "test.ehi"
+    with zipfile.ZipFile(zpath, "w") as zf:
+        zf.writestr("config.json", json.dumps(payload))
+    data = zpath.read_bytes()
+    result = parse_ehi(data)
+    assert result == ["zipline"]
+
+
 def test_parse_line():
     assert parse_line("ssh://user:pass@host:22") == "ssh://user:pass@host:22"


### PR DESCRIPTION
## Summary
- expand tests for `parse_ehi` to cover base64 and zip files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686526b218fc8326bd7deef8b080fb69