### PR TITLE
Support proxy flag in advanced scripts

### DIFF
--- a/advanced_methods/README_advanced.md
+++ b/advanced_methods/README_advanced.md
@@ -14,7 +14,8 @@ the `--sources` option, the default URLs are read from the project-wide
    ```
 3. All scripts accept the common options `--proxy` to route requests through a
    proxy, `--test-timeout` to adjust connection checks, and `--output-dir` to
-   choose where files are written.
+   choose where files are written. Using `--proxy` also updates
+   `vpn_merger.CONFIG.proxy` for consistency with other tools.
 
 ## Output Overview
 

--- a/advanced_methods/argo_merger.py
+++ b/advanced_methods/argo_merger.py
@@ -7,8 +7,11 @@ from typing import List, Optional
 
 import aiohttp
 
-# This script is standalone; proxy settings and timeouts are passed via
-# command line arguments rather than using ``vpn_merger.CONFIG``.
+# These tools share the proxy with ``vpn_merger.CONFIG`` when available.
+try:
+    from vpn_merger import CONFIG
+except Exception:  # pragma: no cover - when running standalone
+    CONFIG = None
 
 
 async def fetch_list(session: aiohttp.ClientSession, url: str, proxy: Optional[str]) -> List[str]:
@@ -77,6 +80,8 @@ def main() -> None:
         if src_file.exists():
             data = json.loads(src_file.read_text())
             sources = data.get('argo', [])
+    if CONFIG is not None:
+        CONFIG.proxy = args.proxy
     asyncio.run(main_async(sources, Path(args.output_dir), args.proxy, args.test_timeout))
 
 

--- a/advanced_methods/http_injector_merger.py
+++ b/advanced_methods/http_injector_merger.py
@@ -10,9 +10,12 @@ from typing import List, Tuple, Optional
 import aiohttp
 from aiohttp import ClientSession
 
-# These advanced merger scripts are intentionally standalone and do not rely
-# on the main ``vpn_merger`` configuration.  Proxy settings and test timeouts
-# are provided via command line arguments instead.
+# These advanced merger scripts update ``vpn_merger.CONFIG.proxy`` when
+# possible so other tools share the same proxy setting.
+try:
+    from vpn_merger import CONFIG
+except Exception:  # pragma: no cover - fallback when not available
+    CONFIG = None
 
 
 async def fetch_text(session: ClientSession, url: str, proxy: Optional[str]) -> str:
@@ -118,6 +121,8 @@ def main() -> None:
         if src_file.exists():
             data = json.loads(src_file.read_text())
             sources = data.get('http_injector', [])
+    if CONFIG is not None:
+        CONFIG.proxy = args.proxy
     asyncio.run(main_async(sources, Path(args.output_dir), args.proxy, args.test_timeout))
 
 

--- a/advanced_methods/tunnel_bridge_merger.py
+++ b/advanced_methods/tunnel_bridge_merger.py
@@ -4,7 +4,11 @@ import json
 from pathlib import Path
 from typing import List, Optional
 
-# Standalone script: accepts its own proxy and timeout options.
+# These scripts also update ``vpn_merger.CONFIG.proxy`` when present.
+try:
+    from vpn_merger import CONFIG
+except Exception:  # pragma: no cover
+    CONFIG = None
 
 
 def parse_line(line: str) -> str:
@@ -78,6 +82,8 @@ def main() -> None:
         if src_file.exists():
             data = json.loads(src_file.read_text())
             sources = data.get('tunnel_bridge', [])
+    if CONFIG is not None:
+        CONFIG.proxy = args.proxy
     asyncio.run(main_async(sources, Path(args.output_dir), args.proxy, args.test_timeout))
 
 

--- a/tests/test_proxy_flag.py
+++ b/tests/test_proxy_flag.py
@@ -1,0 +1,21 @@
+import sys
+import types
+import asyncio
+import importlib
+
+
+def test_proxy_updates_config(monkeypatch):
+    stub = types.ModuleType("vpn_merger")
+    stub.CONFIG = types.SimpleNamespace(proxy=None)
+    monkeypatch.setitem(sys.modules, "vpn_merger", stub)
+
+    import advanced_methods.argo_merger as argo
+    
+    async def dummy_async(*args, **kwargs):
+        return None
+    monkeypatch.setattr(argo, "main_async", dummy_async)
+    monkeypatch.setattr(asyncio, "run", lambda coro: asyncio.get_event_loop().run_until_complete(coro))
+
+    monkeypatch.setattr(sys, "argv", ["argo_merger.py", "--proxy", "http://proxy"])
+    argo.main()
+    assert stub.CONFIG.proxy == "http://proxy"


### PR DESCRIPTION
## Summary
- update advanced scripts to share proxy setting with main CONFIG
- document that `--proxy` modifies `CONFIG.proxy`
- ensure tests check proxy flag behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656b1d5e308326982487f0fac8096e